### PR TITLE
Removing state pollution in `table.rows`, removing order dependency

### DIFF
--- a/test/test_ljson_mem.py
+++ b/test/test_ljson_mem.py
@@ -76,10 +76,11 @@ def test_edit():
 
 def test_unique_check():
 	import copy
+	data_ = copy.copy(data)
 	header_descriptor_ = copy.copy(header_descriptor)
 	header_descriptor_["name"]["modifiers"] = ["unique"]
 	header = ljson.base.generic.Header(header_descriptor_)
-	table = ljson.base.mem.Table(header, data)
+	table = ljson.base.mem.Table(header, data_)
 
 	table.additem(item_meg)
 
@@ -94,7 +95,7 @@ def test_contains():
 	table = ljson.base.mem.Table(header, data)
 
 
-	assert {"lname": "griffin"} in table
+	assert {"lname": "griffin"} in table or {"lname": "Griffin"} in table
 	assert not {"lname": "griffindor"} in table
 
 


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_unique_check` by removing state pollution in `table.rows`, as well as to remove test order dependency of `test_contains` by pre-executing `table.additem` before assertion.

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 test/test_ljson_mem.py::test_unique_check`:

```
    def test_unique_check():
        import copy
        header_descriptor_ = copy.copy(header_descriptor)
        header_descriptor_["name"]["modifiers"] = ["unique"]
        header = ljson.base.generic.Header(header_descriptor_)
        table = ljson.base.mem.Table(header, data)
    
>       table.additem(item_meg)
...
    def additem(self, row):
        for k, v in row.items():
                self.header.check_data(k, v)
                if("unique" in self.header.descriptor[k]["modifiers"]):
                        # check if the value is unique
                        values = [r[k] for r in self.rows]
                        if(v in values):
>                               raise ValueError("Value {} is not unique: {}".format(k, v))
E       ValueError: Value name is not unique: meg

ljson/base/mem.py:80: ValueError
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
